### PR TITLE
Add more packages, locales and allow importing repository public key from URL

### DIFF
--- a/builder/build/filesystem.py
+++ b/builder/build/filesystem.py
@@ -139,7 +139,7 @@ def add_file(ctx: ArchBuilderContext, file: dict):
 			src = os.path.join(ctx.dir, src)
 		log.debug(f"copy {src} to {real}")
 		if folder:
-			shutil.copytree(src, real, symlinks=follow)
+			shutil.copytree(src, real, symlinks=follow, dirs_exist_ok=True)
 		else:
 			shutil.copyfile(src, real, follow_symlinks=follow)
 	else:

--- a/builder/build/filesystem.py
+++ b/builder/build/filesystem.py
@@ -96,8 +96,8 @@ def add_file(ctx: ArchBuilderContext, file: dict):
 	# at least path content
 	if "path" not in file:
 		raise ArchBuilderConfigError("no path set in file")
-	if "content" not in file and "source" not in file:
-		raise ArchBuilderConfigError("no content or source set in file")
+	if "content" not in file and "source" not in file and "url" not in file:
+		raise ArchBuilderConfigError(f"no content, source or url set in file")
 	root = ctx.get_rootfs()
 	path: str = file["path"]
 	if path.startswith("/"): path = path[1:]
@@ -109,7 +109,7 @@ def add_file(ctx: ArchBuilderContext, file: dict):
 	# follow symbolic links
 	follow = file["follow"] if "follow" in file else True
 
-	# source is a folder 
+	# source is a folder
 	folder = file["folder"] if "folder" in file else False
 
 	# files mode
@@ -142,6 +142,10 @@ def add_file(ctx: ArchBuilderContext, file: dict):
 			shutil.copytree(src, real, symlinks=follow, dirs_exist_ok=True)
 		else:
 			shutil.copyfile(src, real, follow_symlinks=follow)
+	elif "url" in file:
+		cmds = ["wget", file["url"], "-O", real]
+		ret = ctx.run_external(cmds)
+		if ret != 0: raise OSError(f"wget failed with {ret}")
 	else:
 		assert False
 	log.debug(f"chmod file {real} to {mode:04o}")

--- a/builder/build/pacman.py
+++ b/builder/build/pacman.py
@@ -64,7 +64,7 @@ def gen_config(ctx: ArchBuilderContext, pacman: Pacman):
 	conf = os.path.join(ctx.get_rootfs(), "etc/pacman.conf")
 	lines: list[str] = []
 	append_config(ctx, lines)
-	pacman.append_repos(lines)
+	pacman.append_repos(lines, True)
 	with open_config(conf) as f:
 		f.writelines(lines)
 	log.info(f"generated pacman config {conf}")

--- a/configs/common/pacman-init.yaml
+++ b/configs/common/pacman-init.yaml
@@ -1,0 +1,17 @@
+filesystem:
+  files:
+  - path: /etc/systemd/system/pacman-init.service
+    content: |
+      [Unit]
+      Description=Initializes Pacman keyring
+      Requires=etc-pacman.d-gnupg.mount
+      After=etc-pacman.d-gnupg.mount time-sync.target
+      BindsTo=etc-pacman.d-gnupg.mount
+      Before=archlinux-keyring-wkd-sync.service
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/usr/bin/pacman-key --init
+      ExecStart=/usr/bin/pacman-key --populate
+      [Install]
+      WantedBy=multi-user.target

--- a/configs/desktop/plasma.yaml
+++ b/configs/desktop/plasma.yaml
@@ -2,6 +2,9 @@
 pacman:
   install:
   - plasma
+  - konsole
+  - kate
+  - dolphin
   - sddm
   - packagekit-qt6
 systemd:
@@ -17,3 +20,4 @@ filesystem:
 +also:
 # Ensure NetworkManager is enabled
 - packages/network-manager
+- packages/firefox

--- a/configs/locale/en-US.yaml
+++ b/configs/locale/en-US.yaml
@@ -1,0 +1,33 @@
+# I18N for English (US)
+locale:
+  enable:
+  - "en_US.UTF-8 UTF-8"
+  default: en_US.UTF-8
+
+systemd:
+  enable:
+  - systemd-timesyncd
+
+filesystem:
+  files:
+  # Wireless regulatory
+  - path: /etc/conf.d/wireless-regdom
+    content: |
+      WIRELESS_REGDOM="US"
+  # Windows NTP Server
+  - path: /etc/systemd/timesyncd.conf.d/windows-ntp.conf
+    content: |
+      [Time]
+      NTP=time.windows.com
+
+sysconf:
+  environments:
+    GTK_IM_MODULE: ibus
+    QT_IM_MODULE: ibus
+    XMODIFIERS: '@im=ibus'
+    COUNTRY: US
+    LANG: en_US.UTF-8
+    LANGUAGE: en_US.UTF-8
+    LC_ALL: en_US.UTF-8
+    TZ: US/Eastern
+timezone: US/Eastern

--- a/configs/locale/ru-RU.yaml
+++ b/configs/locale/ru-RU.yaml
@@ -1,0 +1,33 @@
+# I18N for Russian
+locale:
+  enable:
+  - "ru_RU.UTF-8 UTF-8"
+  - "en_US.UTF-8 UTF-8"
+  default: en_US.UTF-8
+
+systemd:
+  enable:
+  - systemd-timesyncd
+
+filesystem:
+  files:
+  # Wireless regulatory
+  - path: /etc/conf.d/wireless-regdom
+    content: |
+      WIRELESS_REGDOM="RU"
+  - path: /etc/systemd/timesyncd.conf.d/ntp-pool-ntp.conf
+    content: |
+      [Time]
+      NTP=0.ru.pool.ntp.org
+
+sysconf:
+  environments:
+    GTK_IM_MODULE: ibus
+    QT_IM_MODULE: ibus
+    XMODIFIERS: '@im=ibus'
+    COUNTRY: RU
+    LANG: ru_RU.UTF-8
+    LANGUAGE: ru_RU.UTF-8
+    LC_ALL: ru_RU.UTF-8
+    TZ: Europe/Moscow
+timezone: Europe/Moscow

--- a/configs/packages/firefox.yaml
+++ b/configs/packages/firefox.yaml
@@ -1,0 +1,4 @@
+# Firefox
+pacman:
+  install:
+  - firefox

--- a/configs/packages/nvim.yaml
+++ b/configs/packages/nvim.yaml
@@ -1,0 +1,10 @@
+pacman:
+  install:
+    - neovim
+    - neovide
+    - less
+sysconf:
+  environments:
+    EDITOR: nvim
+    VISUAL: neovide
+    PAGER: less

--- a/configs/repo/endeavouros.yaml
+++ b/configs/repo/endeavouros.yaml
@@ -1,0 +1,12 @@
+pacman:
+  repo:
+  - name: endeavouros
+    priority: 200
+    server: https://github.com/endeavouros-team/repo/raw/master/$$repo/$$arch/
+    mirrorlist: https://raw.githubusercontent.com/endeavouros-team/PKGBUILDS/master/endeavouros-mirrorlist/endeavouros-mirrorlist
+  trust:
+  - info@endeavouros.com
+  - manuel@endeavouros.com
+  install:
+  - endeavouros/endeavouros-keyring
+  - endeavouros/endeavouros-mirrorlist

--- a/configs/shell/bash.yaml
+++ b/configs/shell/bash.yaml
@@ -1,0 +1,3 @@
+pacman:
+  install:
+    - bash

--- a/configs/shell/fish.yaml
+++ b/configs/shell/fish.yaml
@@ -1,0 +1,4 @@
+pacman:
+  install:
+    - fish
+    - fisher


### PR DESCRIPTION
Public key import probably needs more work. Currently, one has to run `pacman-key --init && pacman-key --populate` after each boot. Any suggestions for that matter?
[This](https://github.com/anonymix007/arch-image-builder/blob/x1e-t14s/configs/repo/linux-t14s.yaml#L6) is an example of how one would use this feature. Not sure whether there is a better approach to this though without uploading the keys to a keyserver. Any suggestions maybe?